### PR TITLE
add API method for getActiveFolderPath

### DIFF
--- a/api.ts
+++ b/api.ts
@@ -10,8 +10,9 @@ import * as vscode from 'vscode';
  * API version information.
  */
 export enum Version {
-    v1 = 1,         // 1.x.x
-    latest = v1,
+    v1 = 1,         // 1.0.x
+    v1_1 = 1.1,     // 1.1.x
+    latest = v1_1,
 }
 
 /**

--- a/api.ts
+++ b/api.ts
@@ -68,6 +68,11 @@ export interface CMakeToolsApi {
      * @param path The file or folder to get the project for.
      */
     getProject(path: vscode.Uri): Promise<Project | undefined>;
+
+    /**
+     * Gets the active workspace folder.
+     */
+    getActiveFolderPath(): string;
 }
 
 export enum UIElement {

--- a/out/api.d.ts
+++ b/out/api.d.ts
@@ -4,7 +4,8 @@ import * as vscode from 'vscode';
  */
 export declare enum Version {
     v1 = 1,
-    latest = 1
+    v1_1 = 1.1,
+    latest = 1.1
 }
 /**
  * The interface provided by the CMake Tools extension during activation.

--- a/out/api.d.ts
+++ b/out/api.d.ts
@@ -53,6 +53,10 @@ export interface CMakeToolsApi {
      * @param path The file or folder to get the project for.
      */
     getProject(path: vscode.Uri): Promise<Project | undefined>;
+    /**
+     * Gets the active workspace folder.
+     */
+    getActiveFolderPath(): string;
 }
 export declare enum UIElement {
     StatusBarLaunchButton = 0,

--- a/out/api.js
+++ b/out/api.js
@@ -21,7 +21,8 @@ const vscode = require("vscode");
 var Version;
 (function (Version) {
     Version[Version["v1"] = 1] = "v1";
-    Version[Version["latest"] = 1] = "latest";
+    Version[Version["v1_1"] = 1.1] = "v1_1";
+    Version[Version["latest"] = 1.1] = "latest";
 })(Version = exports.Version || (exports.Version = {}));
 var UIElement;
 (function (UIElement) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-cmake-tools",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-cmake-tools",
-            "version": "1.0.0",
+            "version": "1.1.0",
             "license": "MIT",
             "devDependencies": {
                 "@types/node": "~14.14.28",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-cmake-tools",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "description": "Public API for vscode-cmake-tools",
     "typings": "./out/api.d.ts",
     "main": "./out/api.js",


### PR DESCRIPTION
See title.

Add an api method for `getActiveFolderPath` which returns a string representing the active workspace folder. 

Updates the minor version of the version number because this adds non-breaking features. 